### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled command line

### DIFF
--- a/Season-2/Level-3/package.json
+++ b/Season-2/Level-3/package.json
@@ -15,11 +15,12 @@
       "fs": "^0.0.1-security",
       "libxmljs": "^1.0.9",
       "multer": "^2.0.2",
-      "path": "^0.12.7"
+      "path": "^0.12.7",
+      "shell-quote": "^1.8.3"
     },
     "devDependencies": {
       "chai": "^4.3.8",
       "mocha": "^10.2.0",
       "supertest": "^6.3.3"
     }
-  }
+}


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/vigilant-system/security/code-scanning/14](https://github.com/se2026/vigilant-system/security/code-scanning/14)

To fix this vulnerability, we should never pass untrusted user input as the command line for `exec`. The recommended fix is to use `execFile` instead of `exec`, providing the command and its arguments as an array. This eliminates shell parsing vulnerabilities. However, since the code currently accepts arbitrary command lines from user input (which can be anything), we must restrict which commands can be executed. The best mitigation is to permit only a known, limited set of commands (e.g., using a hardcoded allowlist of safe commands, and/or validating the content to accept only specific allowed commands and benign arguments), and reject or ignore any others.

Specifically, in file Season-2/Level-3/code.js:  
- Change line(s) inside the XML command execution branch (lines 72–81) to:  
  - Only allow specific commands, e.g., only permit `ls`, `cat`, etc.  
  - Parse the command string into an argument array securely (using `shell-quote` library).  
  - Use `execFile` or `execFileSync` to execute only allowed commands, passing arguments as an array.  
  - Reject or safely handle commands not on the allowlist.  
- Add an import for `shell-quote`.  
- No other code outside the shown snippet should be changed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
