### PR TITLE
Potential fix for code scanning alert no. 18: Missing rate limiting

### DIFF
--- a/Season-2/Level-3/package.json
+++ b/Season-2/Level-3/package.json
@@ -16,7 +16,8 @@
       "libxmljs": "^1.0.9",
       "multer": "^2.0.2",
       "path": "^0.12.7",
-      "shell-quote": "^1.8.3"
+      "shell-quote": "^1.8.3",
+      "express-rate-limit": "^8.1.0"
     },
     "devDependencies": {
       "chai": "^4.3.8",


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/vigilant-system/security/code-scanning/18](https://github.com/se2026/vigilant-system/security/code-scanning/18)

To address the missing rate-limiting vulnerability, we should add a rate-limiting middleware to the `/ufo/upload` route. The best, simplest, and most widely adopted method in Express apps is to use the `express-rate-limit` package. 

The process:

- Add an import/require of `express-rate-limit`.
- Create a rate limiter instance, for example permitting 5 uploads per minute per IP.
- Add this as middleware to the `/ufo/upload` route (not globally, to avoid breaking other endpoints or tests).

1. Add at the top: `const rateLimit = require("express-rate-limit");`
2. Below your other middleware setup but before the `/ufo/upload` route define a limiter, e.g.:
   ```
   const uploadLimiter = rateLimit({
     windowMs: 60 * 1000, // 1 minute
     max: 5, // limit each IP to 5 upload requests per minute
     message: "Too many uploads, please try again later.",
   });
   ```
3. Modify the route to add this middleware:
   ```
   app.post("/ufo/upload", uploadLimiter, upload.single(...), ...)
   ```
Only these changes are necessary to add robust rate-limiting to the upload route. No existing functionality will be affected except for blocking excessive upload attempts.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
