### PR TITLE
Potential fix for code scanning alert no. 7: Uncontrolled data used in path expression

### DIFF
--- a/Season-1/Level-3/code.py
+++ b/Season-1/Level-3/code.py
@@ -48,8 +48,15 @@ class TaxPayer:
         if not path:
             raise Exception("Error: Tax form is required for all users")
 
-        with open(path, 'rb') as form:
+        # Defend against path traversal and restrict to "tax_forms" subdirectory
+        base_dir = os.path.dirname(os.path.abspath(__file__))
+        tax_forms_base = os.path.join(base_dir, 'tax_forms')
+        safe_path = os.path.normpath(os.path.join(tax_forms_base, path))
+        if not safe_path.startswith(tax_forms_base):
+            raise Exception("Error: Invalid tax form path")
+
+        with open(safe_path, 'rb') as form:
             tax_data = bytearray(form.read())
 
         # assume that tax data is returned on screen after this
-        return path
+        return safe_path


### PR DESCRIPTION
Potential fix for [https://github.com/se2026/vigilant-system/security/code-scanning/7](https://github.com/se2026/vigilant-system/security/code-scanning/7)

To fix the problem, paths constructed from untrusted user input should be validated before use. The best way, consistent with the recommended practices presented, is to ensure that the path the user provides is restricted to a safe directory. This means first using `os.path.normpath` to normalize the path and then joining it to a trusted base directory and checking that the result starts with that directory, thereby preventing path traversal and absolute path attacks. The fix should be implemented within the `get_tax_form_attachment` method (lines 45–55), in analogy with the logic used in `get_prof_picture` but strengthened. It's best to define a trusted directory for tax form attachments (for instance, a subdirectory named `tax_forms` under the app's base directory), normalize the path, join it, and check that the final resolved path is within that directory.

To implement this:
- Define the trusted base directory for tax forms.
- Normalize and join the user input to this base directory.
- Check if the resulting path starts with the safe base.
- Open the file only if the check passes; otherwise, raise an error.

No new methods or external libraries are needed. Edits should only be made to lines inside the `get_tax_form_attachment` method.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
